### PR TITLE
Add docker file path input to python script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ function main() {
   sanitize "${INPUT_ACCOUNT_ID}" "account_id"
   sanitize "${INPUT_REPO}" "repo"
   sanitize "${INPUT_ASSUME_ROLE}" "assume_role"
+  sanitize "${INPUT_PATH}" "path"
 
   ACCOUNT_URL="$INPUT_ACCOUNT_ID.dkr.ecr.$INPUT_REGION.amazonaws.com"
 


### PR DESCRIPTION
Though the documentation shows the ability to take the path to the docker file as input, it seems that we never actually map it in the initial step