### PR TITLE
perf: build and deploy action image to gcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: docker login
+        run: |
+          echo "$GCR_TOKEN" | docker login ghcr.io -u kciter --password-stdin
+        env:
+          GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
+
+      - name: build and push latest docker image to GCR
+        run: |
+          docker build -t ghcr.io/kciter/aws-ecr-action:latest .
+          docker push ghcr.io/kciter/aws-ecr-action:latest

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ This Action allows you to create Docker images and push into a ECR repository.
 | `prebuild_script` | `string` | | Relative path from top-level to script to run before Docker build |
 
 ## Usage
+
 ```yaml
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: kciter/aws-ecr-action@master
+    - uses: docker://ghcr.io/kciter/aws-ecr-action:latest
       with:
         access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -37,6 +38,16 @@ jobs:
         create_repo: true
         set_repo_policy: true
         repo_policy_file: repo-policy.json
+```
+
+If you don't want to use the latest docker image, you can point to any reference in the repo directly.
+
+```yaml
+  - uses: kciter/aws-ecr-action@master
+  # or
+  - uses: kciter/aws-ecr-action@v2
+  # or
+  - uses: kciter/aws-ecr-action@0589ad88c51a1b08fd910361ca847ee2cb708a30
 ```
 
 ## Reference


### PR DESCRIPTION
Love the action and use it very heavily at work! Thanks so much.

Similar to the request here: https://github.com/kciter/aws-ecr-action/issues/17

**Problem**: Currently this action takes about 35-40 seconds just to build before it can ever be used. This just adds time to everyones CI/CD workflows unnecessarily.

**Solution**: This PR builds the action image and publishes to GCR. Downstream consumers/users of the action like myself can then just do:

```diff
-  - uses: kciter/aws-ecr-action@master
+  - uses: docker://ghcr.io/kciter/aws-ecr-action:latest
```

This allows our workflows to simply **pull** the image instead of **building** the image ourselves on every run. 

‼️  **This should drop the time from 35-40s to about _4s_.**

## Action items you need to take for this to work:

1. Go create a personal access token https://github.com/settings/tokens (GITHUB_TOKEN will not have proper perms for this action)
2. Give it the proper scope: https://share.getcloudapp.com/2Nuw17BL
3. Go into the repo's `Secrets` settings area and create a new secret named `GCR_TOKEN` and set it to the personal access token you just created. https://github.com/kciter/aws-ecr-action/settings/secrets/actions
4. That's it!

You can add fanciness in the future to publish different versions and things, but i think this would be a fantastic first step to optimize things greatly!