### PR TITLE
Pin to specific pyyaml version - fixes #20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk update \
   && apk upgrade \
   && apk add --no-cache --update python py-pip coreutils bash \
   && rm -rf /var/cache/apk/* \
-  && pip install awscli==1.18.95 \
+  && pip install pyyaml==5.3.1 \
+  && pip install -U awscli \
   && apk --purge -v del py-pip
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
As a result of [this](https://github.com/aws/aws-cli/issues/6094) awscli issue which causes the module to break https://github.com/kciter/aws-ecr-action/issues/20, I'm proposing pinning to a specific pyyaml version instead of keeping an outdated awscli version.

I've locally tested the new Dockerfile and it builds.

Please consider this change. 

Thank you!