### PR TITLE
fix: set defaults in entrypoint to prevent failures for images

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+INPUT_PATH="${INPUT_PATH:-.}"
+INPUT_DOCKERFILE="${INPUT_DOCKERFILE:-Dockerfile}"
+INPUT_TAGS="${INPUT_TAGS:-latest}"
+INPUT_CREATE_REPO="${INPUT_CREATE_REPO:-false}"
+INPUT_SET_REPO_POLICY="${INPUT_PATH:-false}"
+INPUT_REPO_POLICY_FILE="${INPUT_PATH:-repo-policy.json}"
+
 function main() {
   sanitize "${INPUT_ACCESS_KEY_ID}" "access_key_id"
   sanitize "${INPUT_SECRET_ACCESS_KEY}" "secret_access_key"


### PR DESCRIPTION
Fixes #22

FYI @kciter 

There's an issue with GitHub Actions when relying on default inputs when using a docker image: https://github.community/t/when-using-prebuilt-image-uses-docker-inputs-not-explicitly-set-in-with-arent-sent-in-docker-run/174666

> If you directly use the Docker image, there is no action.yml file to be parsed, just the Docker image. In that case you need to set any defaults within the image (e.g. in a script that reads the inputs).

This fixes the issue