### PR TITLE
Implement top level cache-from usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This Action allows you to create Docker images and push into a ECR repository.
 | `tags` | `string` | `latest` | Comma-separated string of ECR image tags (ex latest,1.0.0,) |
 | `dockerfile` | `string` | `Dockerfile` | Name of Dockerfile to use |
 | `extra_build_args` | `string` | `""` | Extra flags to pass to docker build (see docs.docker.com/engine/reference/commandline/build) |
+| `cache_from` | `string` | `""` | Images to use as cache for the docker build (see `--cache-from` argument docs.docker.com/engine/reference/commandline/build) |
 | `path` | `string` | `.` | Path to Dockerfile, defaults to the working directory |
 | `prebuild_script` | `string` | | Relative path from top-level to script to run before Docker build |
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   extra_build_args:
     description: Extra flags to pass to docker build (see docs.docker.com/engine/reference/commandline/build)
     default: ''
+  cache_from:
+    description: Images to use as cache for the docker build (see `--cache-from` argument docs.docker.com/engine/reference/commandline/build)
+    default: ''
   path:
     description: Path to Dockerfile, defaults to the working directory
     default: .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,6 +114,14 @@ function docker_build() {
     docker_tag_args="$docker_tag_args -t $2/$INPUT_REPO:$tag"
   done
 
+  if [ -n "${INPUT_CACHE_FROM}" ]; then
+    for i in ${INPUT_CACHE_FROM//,/ }; do
+      docker pull $i
+    done
+
+    INPUT_EXTRA_BUILD_ARGS="$INPUT_EXTRA_BUILD_ARGS --cache-from=$INPUT_CACHE_FROM"
+  fi
+
   docker build $INPUT_EXTRA_BUILD_ARGS -f $INPUT_DOCKERFILE $docker_tag_args $INPUT_PATH
   echo "== FINISHED DOCKERIZE"
 }


### PR DESCRIPTION
Per #9, you can currently utilize `extra_build_args` to implement a caching strategy with additional work to pull the images first, but it seems like this would be useful as a first-class option.

Coincidentally, the code to implement inside the action is shorter than the YAML required to work around it not being there 😂. 