### PR TITLE
Removing image scanning from input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Action allows you to create Docker images and push into a ECR repository.
 | `create_repo` | `boolean` | `false` | Set this to true to create the repository if it does not already exist |
 | `set_repo_policy` | `boolean` | `false` | Set this to true to set a IAM policy on the repository |
 | `repo_policy_file` | `string` | `repo-policy.json` | Set this to repository policy statement json file. only used if the set_repo_policy is set to true |
-| `image_scanning_configuration:` | `boolean` | `false` | Set this to True if you want AWS to scan your images for vulnerabilities |
+| `image_scanning_configuration` | `boolean` | `false` | Set this to True if you want AWS to scan your images for vulnerabilities |
 | `tags` | `string` | `latest` | Comma-separated string of ECR image tags (ex latest,1.0.0,) |
 | `dockerfile` | `string` | `Dockerfile` | Name of Dockerfile to use |
 | `extra_build_args` | `string` | `""` | Extra flags to pass to docker build (see docs.docker.com/engine/reference/commandline/build) |
@@ -38,6 +38,7 @@ jobs:
         region: ap-northeast-2
         tags: latest,${{ github.sha }}
         create_repo: true
+        image_scanning_configuration: true
         set_repo_policy: true
         repo_policy_file: repo-policy.json
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,6 @@ function main() {
   sanitize "${INPUT_REGION}" "region"
   sanitize "${INPUT_ACCOUNT_ID}" "account_id"
   sanitize "${INPUT_REPO}" "repo"
-  sanitize "${INPUT_IMAGE_SCANNING_CONFIGURATION}" "image_scanning_configuration"
 
   ACCOUNT_URL="$INPUT_ACCOUNT_ID.dkr.ecr.$INPUT_REGION.amazonaws.com"
 


### PR DESCRIPTION
@kciter I am not sure why the warning was leading to the image scanning feature to no work. However, I tested again and this works fine with no error and does scan the image upon pushing to ECR.