### PR TITLE
add registry-ids, move from deprecated get-login to get-login-password

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This Action allows you to create Docker images and push into a ECR repository.
 | `cache_from` | `string` | `""` | Images to use as cache for the docker build (see `--cache-from` argument docs.docker.com/engine/reference/commandline/build) |
 | `path` | `string` | `.` | Path to Dockerfile, defaults to the working directory |
 | `prebuild_script` | `string` | | Relative path from top-level to script to run before Docker build |
+| `registry_ids` | `string` | | : A comma-delimited list of AWS account IDs that are associated with the ECR registries. If you do not specify a registry, the default ECR registry is assumed |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   account_id:
     description: AWS Account ID
     required: true
+  registry_ids:
+    description: A comma-delimited list of AWS account IDs that are associated with the ECR registries. If you do not specify a registry, the default ECR registry is assumed
+    required: false
+    default: ''
   assume_role:
     description: A role to assume under the account_id account.
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,8 +44,15 @@ function aws_configure() {
 
 function login() {
   echo "== START LOGIN"
-  LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-  $LOGIN_COMMAND
+  if [ "${INPUT_REGISTRY_IDS}" == "" ]; then
+    INPUT_REGISTRY_IDS=$INPUT_ACCOUNT_ID
+  fi
+  
+  for i in ${INPUT_REGISTRY_IDS//,/ }
+  do
+    aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $i.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+  done
+  
   echo "== FINISHED LOGIN"
 }
 


### PR DESCRIPTION
I had a requirement to be able to log in to 2 diferent registries so that i could use an image as a source that is stored in a different AWS account than the one i am pushing to.

Also get-login is deprecated so just updated to use get-login-password

we are using this internally and it works but want to provide it back to the community in case others have the same use case.